### PR TITLE
Change to JACK input clients

### DIFF
--- a/doc/splitting-audio.md
+++ b/doc/splitting-audio.md
@@ -4,15 +4,14 @@ In this document we will be setting up Virtual Audio Inputs and splitting audio 
 
 # qpwgraph
 
-- This is the app that will let us split audio easily with a GUI.
-- You can download it by executing this in your terminal
+This is the app that will let us split audio easily with a GUI. You can download it by executing this in your terminal
 
 ```
 sudo dnf install qpwgraph
 ```
 
-- We now need to setup `qpwgraph` such that it launches each time with the correct arguments on startup.
-- Copy the following contents into a file named `qpwgraph.desktop` and drop it in `~/.config/autostart/`.
+We now need to setup `qpwgraph` such that it launches each time with the correct arguments on startup.  
+Copy the following contents into a file named `qpwgraph.desktop` and drop it in `~/.config/autostart/`
 
 ```
 [Desktop Entry]
@@ -29,63 +28,78 @@ Terminal=false
 Type=Application
 ```
 
-- We will be using this application later on to setup output routing.
-- **NOTE**: If you are using a window manager though, make sure to add `qpwgraph <path_to_config> -axm` to your autostart script for your window manager by replacing `<path_to_config>` with the path of the config you save later on during the setup.
-- Eg: In i3, Say a config is in `~/Speedrunning.qpwgraph`, then we put `exec qpwgraph ~/Speedrunning.qpwgraph -axm` in `~/.config/i3/config`.
+We will be using this application later on to setup output routing.  
 
-# Setting up Virtual Audio Cables
+**NOTE**: If you are using a window manager, make sure to add `qpwgraph <path_to_config> -axm` to your autostart script for your window manager by replacing `<path_to_config>` with the path of the config you save later on during the setup.  
+Eg: In i3, say a config is in `~/Speedrunning.qpwgraph`, then we put `exec qpwgraph ~/Speedrunning.qpwgraph -axm` in `~/.config/i3/config`.
 
-- We setup virtual audio cables by using a script that launches each time you login to your system.
-- Copy the following contents into a file named `virtual_inputs` and in a terminal execute `chmod +x virtual_inputs` to make it executable and then move the file into `/usr/bin`.
+# Setting up Virtual Audio Devices
 
-```bash
-#!/bin/sh
-pactl load-module module-null-sink media.class=Audio/Sink sink_name=Virtual_Input_1
-pactl load-module module-null-sink media.class=Audio/Sink sink_name=Virtual_Input_2
+`virtual-input-1` and `virtual-input-2` can be renamed to make things more easily identifiable for yourself. But for the purpose of this guide, I'll be using those two names.
+
+We're going to use `.conf` files to configure virtual devices. These files should be placed in `~/.config/pipewire/pipewire.conf.d` (for user configuration) or `/etc/pipewire/pipewire.conf.d` (for system-wide configuration).
+
+First, add a file `virtual-input-1.conf` with the following contents.
+```
+context.objects = [
+	{	factory = adapter
+		args = {
+			factory.name = support.null-audio-sink
+			node.name = "virtual-intput-1.conf"
+			media.class = Audio/Sink
+		}
+	}
+]
 ```
 
-- If you don't have the `pactl` command you can install it by executing `sudo dnf install pulseaudio-utils`.
-- The above script is to make 2 virtual inputs which are more than enough to do basic audio splitting. You can add more by just copying and pasting these lines and changing the `sink_name` to `Virtual_Input_3` and so on.
-- Now we can setup `virtual_inputs` to launch on startup.
-- Copy the following contents into a file named `virtual_inputs.desktop` and drop it in `~/.config/autostart/`.
+Next, add another file `virtual-input-2.conf` with the following contents.
 
 ```
-[Desktop Entry]
-Encoding=UTF-8
-Type=Application
-Exec=virtual_inputs
-Terminal=false
-Name=Virtual Inputs
+context.objects = [
+	{	factory = adapter
+		args = {
+			factory.name = support.null-audio-sink
+			node.name = "virtual-input-2.conf"
+			media.class = Audio/Sink
+		}
+	}
+]
 ```
 
-- Now you can logout and login to your system and see that an icon is added to your taskbar at the very right.
-- **NOTE**: If you are using a window manager though, make sure to add `virtual_inputs &` to your autostart script for your window manager.
-- Eg: In i3, we would add `exec virtual_inputs` to `~/.config/i3/config`
+
+This will create two virtual audio devices whenever pipewire service starts. If you want to have more virtual devices, you may add more to your liking. To take immediate effect, you can simply restart pipewire service with the command
+
+```
+systemctl --user daemon-reload && systemctl --user restart pipewire
+```
+
+qpwgraph should now show two nodes with the names `virtual-input-1` and `virtual-input-2`.
+
 
 # Setting up OBS
 
-- We setup OBS now to add two JACK Audio Inputs which will take the outputs from the virtual audio cables and splits it out.
-- Go into your OBS Settings and disable `Desktop Audio` from the `Audio` tab by selecting `Disabled` against the `Desktop Audio` option.
-- In each of your `Wall` and `Instance` scenes, click on the `+` icon and add a `JACK Input Client` and name it `Desktop Audio` and `Spotify`.
-- Accept the defaults on the `JACK Input Client`.
+Open up `Settings` and go to the `Audio` tab, click on the drop down menu for `Desktop Audio` and pick `virtual-input-1`. Do the same for `Desktop Audio 2` except for `virtual-input-2`.
+
+If you have any more virtual device that you want to route, you may add `Audio Output Capture` sources and use the other virtual devices that way. Note that if you do this, you would be required to add the sources to all other scenes.
 
 # Setting up Audio Splits
 
-- Open up qpwgraph.
-- Connect your audio outputs to the virtual inputs.
-- Connect your spotify output to any of the virtual input as well by connecting the left and right outputs to the left and right inputs respectively. You can get it visible in the graph by opening up spotify and playing any music.
-- Make sure to also route your Virtual Input Devices to the physical output device that you would like to use. For example your headphones.
-- Make sure to route `Built-in Audio Analog Stereo` captures or your Mic captures to your `OBS [Mic/Aux]` input. It might be done automatically but sometimes it might need a little fixing.
-- Now you can route the virtual inputs to your OBS JACK inputs. It will be usually named something like `OBS Studio: Desktop Audio` and `OBS Studio: Spotify`.
-- As a convention, you can use `OBS Studio: Spotify` to be the one that doesn't get published to the VoD and `OBS Studio: Desktop Audio` to be published to the VoD.
-- You can set this up by going into your `Advanced Audio Settings` and then routing which audio streams `Desktop Audio` and `Spotify` go to and you can enable `Twitch VoD Track` from the `Output` tab.
-- Now hit `Ctrl + S` to save changes in qpwgraph. If this somehow doesn't work, you can try qutting the application by right clicking on the taskbar icon and choosing `Exit`. It should prompt you to save it as something. Save it giving it any name you choose and close.
-- Now qpwgraph should startup each time you login with that graph applied, so the audio connections would be made automatically as the instances, OBS and spotify launch.
-- Sometimes with the Spotify desktop app you might have some issues with the connections flickering from one Virtual Input to the other. If so, please post an issue [here](https://github.com/sathya-pramodh/linux-mcsr/issues).
-- Now go into your Fedora settings and go into the `Audio` settings tab and set the current audio device that you are using to be any of the virtual inputs that you want. Mind you, this step is done because you would want all your game audio to be routed to that virtual input because the audio outputs of Minecraft gets re-routed each time there is a sound played for some reason.
+Open up qpwgraph and you should see the nodes `virtual-input-1` connecting to `OBS [Desktop Audio]` and `virtual-input-2` connecting to `OBS-1 [Desktop Audio 2]` or something similar.
+
+If you wanna not have your Spotify music appear on VODs, you can route Spotify into one of the virtual devices, like `virtual-input-2`, by dragging `output_FL` to `playback_FL` and `output_FR` to `playback_FR`.
+
+Now on OBS, go into `Settings`, then to the `Output` tab. Under `Streaming`, tick the `Twitch VOD Track` box. If you're on simple output mode, it should default to 2. If you're in advanced output mode, pick 2.
+
+Now go back to the your OBS scene and click on the gear icon under `Audio Mixer`. There, you'll deselect track number 2 of the audio that contains your Spotify music. In this case, that is `Desktop Audio 2`. So deselect track 2 of `Desktop Audio 2` and now your Spotify music will not be inside your Twitch VODs.
+
+Similarly, route any other audio that you want into your virtual device, i.e. your Minecraft instances or lecture videos.
+
+Now hit `Ctrl + S` to save changes in qpwgraph.
+
+If you have any issues regarding Spotify desktop app connections flickering from one virtual device to the other, you may post an issue [here](https://github.com/sathya-pramodh/linux-mcsr/issues).
 
 # All done!
 
 - We are done with setting up audio splitting on Linux.
-- Again, this is very dependent on your hardware and setup and this is highly untested. If you get any issues while setting this up, post an issue [here](https://github.com/sathya-pramodh/linux-mcsr/issues).
+- Again, this is very dependent on your hardware and setup and this is highly untested. If you get any issues while setting this up, post an issue [here](https://github.com/sathya-pramodh/linux-mcsr/issues) or even better, join the [resetti Discord server](https://discord.gg/g9b99fxW) and we'll try and help you.
 - You can go [here](https://github.com/sathya-pramodh/linux-mcsr/blob/main/doc/post-install.md#update-cycle) to continue with the post install instructions.

--- a/doc/splitting-audio.md
+++ b/doc/splitting-audio.md
@@ -45,7 +45,7 @@ context.objects = [
 	{	factory = adapter
 		args = {
 			factory.name = support.null-audio-sink
-			node.name = "virtual-intput-1.conf"
+			node.name = "virtual-input-1"
 			media.class = Audio/Sink
 		}
 	}
@@ -59,7 +59,7 @@ context.objects = [
 	{	factory = adapter
 		args = {
 			factory.name = support.null-audio-sink
-			node.name = "virtual-input-2.conf"
+			node.name = "virtual-input-2"
 			media.class = Audio/Sink
 		}
 	}

--- a/doc/splitting-audio.md
+++ b/doc/splitting-audio.md
@@ -78,21 +78,19 @@ qpwgraph should now show two nodes with the names `virtual-input-1` and `virtual
 
 # Setting up OBS
 
-Open up `Settings` and go to the `Audio` tab, click on the drop down menu for `Desktop Audio` and pick `virtual-input-1`. Do the same for `Desktop Audio 2` except for `virtual-input-2`.
-
-If you have any more virtual device that you want to route, you may add `Audio Output Capture` sources and use the other virtual devices that way. Note that if you do this, you would be required to add the sources to all other scenes.
+Now head to OBS and make a scene called `Audio` for the sake of simplicity. Inside the scene, add two `JACK Input Client` sources called `virtual-input-1` and `virtual-input-2`. Just leave the properties as default. After adding the sources within the scene, add the scene to the scenes that you want audio in.
 
 # Setting up Audio Splits
 
-Open up qpwgraph and you should see the nodes `virtual-input-1` connecting to `OBS [Desktop Audio]` and `virtual-input-2` connecting to `OBS-1 [Desktop Audio 2]` or something similar.
+Open up qpwgraph and you should see the nodes `OBS Studio: virtual-input-1` and `OBS Studio: virtual-input-2`. Connect them to the virtual devices by dragging the `monitor_FL` and `monitor_FR` of `virtual-input-1` to `virtual-input-1:in_1` and `virtual-input-1:in_2` of `OBS Studio: virtual-input-1` respectively. Do the same for `OBS Studio: virtual-input-2`.
 
 If you wanna not have your Spotify music appear on VODs, you can route Spotify into one of the virtual devices, like `virtual-input-2`, by dragging `output_FL` to `playback_FL` and `output_FR` to `playback_FR`.
 
 Now on OBS, go into `Settings`, then to the `Output` tab. Under `Streaming`, tick the `Twitch VOD Track` box. If you're on simple output mode, it should default to 2. If you're in advanced output mode, pick 2.
 
-Now go back to the your OBS scene and click on the gear icon under `Audio Mixer`. There, you'll deselect track number 2 of the audio that contains your Spotify music. In this case, that is `Desktop Audio 2`. So deselect track 2 of `Desktop Audio 2` and now your Spotify music will not be inside your Twitch VODs.
+Now go back to the your OBS scene and click on the gear icon under `Audio Mixer`. There, you'll deselect track number 2 of the audio that contains your Spotify music. In this case, that is `virtual-input-2`. So deselect track 2 of `virtual-input-2` and now your Spotify music will not be inside your Twitch VODs.
 
-Similarly, route any other audio that you want into your virtual device, i.e. your Minecraft instances or lecture videos.
+Similarly, route any other audio that you want into your virtual devices, i.e. your Minecraft instances or lecture videos.
 
 Now hit `Ctrl + S` to save changes in qpwgraph.
 


### PR DESCRIPTION
Using Desktop Audios and Audio Output Capture causes janky audio during recording from testing, using JACK input clients somehow does not cause that issue so far.