### PR TITLE
Fixed naming in desktop entry

### DIFF
--- a/doc/minecraft/modcheck.md
+++ b/doc/minecraft/modcheck.md
@@ -8,7 +8,7 @@
 [Desktop Entry]
 Encoding=UTF-8
 Type=Application
-Name=NinjabrainBot
+Name=ModCheck
 Icon=minecraft
 Exec=java -jar /home/<user_name>/Downloads/ModCheck-0.6.jar
 ```


### PR DESCRIPTION
The desktop entry in the ModCheck doc contained the name as `NinjabrainBot` instead of `ModCheck`, so this fixes that minor issue.