### PR TITLE
fix: retain 1000 worlds instead of 6 in tmpfs

### DIFF
--- a/doc/tmpfs.md
+++ b/doc/tmpfs.md
@@ -95,7 +95,7 @@ while true
 do
     for i in {1..X}
     do
-        for save in $(ls /tmp/mc/$i -t1 --ignore=Z* | tail -n +100)
+        for save in $(ls /tmp/mc/$i -t1 --ignore=Z* | tail -n +1000)
         do
             rm -r "/tmp/mc/$i/$save"
         done

--- a/doc/tmpfs.md
+++ b/doc/tmpfs.md
@@ -95,7 +95,7 @@ while true
 do
     for i in {1..X}
     do
-        for save in $(ls /tmp/mc/$i -t1 --ignore=Z* | tail -n +6)
+        for save in $(ls /tmp/mc/$i -t1 --ignore=Z* | tail -n +100)
         do
             rm -r "/tmp/mc/$i/$save"
         done


### PR DESCRIPTION
Bop all worlds other than the recent `1000` to prevent verification issues with seedqueue.

Work towards: #29 