### PR TITLE
fix: Fixed waywall installation instructions for fedora and debian and more specific stuff related to ubuntu

### DIFF
--- a/doc/minecraft/wayland/waywall.md
+++ b/doc/minecraft/wayland/waywall.md
@@ -11,7 +11,7 @@
 ## Installation
 - To install waywall on **Fedora**:
   - **Fedora 42 onwards**, prebuilt binaries are available and is **recommended** way to install waywall. Please download `**.x86_64.rpm` package from [releases of waywall](https://github.com/tesselslate/waywall/releases). 
-    - If you are using KDE Plasma(default with Desktop edition of fedora), installation can be done by double clicking on .rpm file and installing it via Discover app.
+    - If you are using KDE Plasma(default with Desktop edition of Fedora), installation can be done by double clicking on .rpm file and installing it via Discover app.
     - In any other case you can use, `sudo rpm -i [path_to_rpm_file]` provide path to `.rpm` file. 
     
       Expample: `sudo dnf install ~/Downloads/waywall.x86_64.rpm`
@@ -28,14 +28,14 @@
     
 
 - On **Arch Linux**, [you can install waywall through the AUR](https://aur.archlinux.org/packages/waywall-working-git).
-- On **Debian** , prebuilt binaries are available for waywall however they only work with **Debian 13 and up** as older version do not have updated dependancies to run waywall. Please download `.deb` version from [releases of waywall](https://github.com/tesselslate/waywall/releases).  
+- On **Debian** , prebuilt binaries are available for waywall however they only work with **Debian 13 and up** as older versions do not have updated dependancies to run waywall. Please download `.deb` version from [releases of waywall](https://github.com/tesselslate/waywall/releases).  
   - Installtion of package can be done by double clicking on `.deb` and installing using default system install.
   - In any other case apt can be used to install .deb packages using following command.
   `sudo apt install locationTodebfile` eg. `sudo apt install ~/Downloads/waywall.deb`
 - On **Ubuntu**/**Ubuntu based Distros (Linux Mint, MX Linux, Pop OS! etc)**, 
   
   - **Ubuntu 26.04** has been tested and verified  working with waywall using `.deb` package. Follow the same installations instruction as Debian.
-  - **Linux Mint 22.3 and below/Any distro based on Ubuntu 24.04 or below** cannot run waywall due outdated dependancies and should use switch to x11 and use [resetti](../x11/resetti.html) instead. 
+  - **Linux Mint 22.3 and below/Any distro based on Ubuntu 24.04 or below** cannot run waywall due outdated dependancies and should switch to x11 and use [resetti](../x11/resetti.html) instead. 
 
 ## Verification of installation and next steps
 - Run `waywall` in a terminal to check it's installed properly.
@@ -52,14 +52,14 @@ it should produce similar ouput:
           --no-env-reexec          Disable re-executing waywall with the parent process'
                                   environment
   ```
-- In case it doesn't or ouputs waywall command not found.
+- In case it doesn't or ouputs waywall command not found
   - If you have installed waywall from prebuilt binaries, verify that waywall exist in following path `/usr/bin/waywall` in case it doesn't please reinstall waywall.                           
   - In case you are building waywall from source
     - Use the absolute path to the waywall executable and verify it works (i.e. if you built waywall in `/home/username/waywall/build/waywall`, run `/home/username/waywall/build/waywall/waywall`).
-    - The wrapper command for your instance in the next step should also reflect this path in your launcher i.e instead of `waywall wrap --`, it should be path where waywall build is present i.e `/home/username/waywall/build/waywall/waywall wrap --`
+    - The wrapper command for your instance in the next step should also reflect this path in your launcher .i.e instead of `waywall wrap --`, it should be path where waywall build is present i.e `/home/username/waywall/build/waywall/waywall wrap --`
 - Once waywall is installed properly, visit the [next page of the documentation](https://tesselslate.github.io/waywall/00_setup.html) to patch GLFW and set up your instance to launch within waywall.
 
-- After this, move to the [next section](waywall-config.html) to install an example config and learn how to customize it to your liking.
+- After this, move on to the [next section](waywall-config.html) to install an example config and learn how to customize it to your liking.
 
 ## Troubleshooting
 

--- a/doc/minecraft/wayland/waywall.md
+++ b/doc/minecraft/wayland/waywall.md
@@ -9,22 +9,54 @@
 - If you're using **X11**, please use [resetti](../x11/resetti.html) instead.
 
 ## Installation
+- To install waywall on **Fedora**:
+  - **Fedora 42 onwards**, prebuilt binaries are available and is **recommended** way to install waywall. Please download `**.x86_64.rpm` package from [releases of waywall](https://github.com/tesselslate/waywall/releases). 
+    - If you are using KDE Plasma(default with Desktop edition of fedora), installation can be done by double clicking on .rpm file and installing it via Discover app.
+    - In any other case you can use, `sudo rpm -i [path_to_rpm_file]` provide path to `.rpm` file. 
+    
+      Expample: `sudo dnf install ~/Downloads/waywall.x86_64.rpm`
+    
 
-- To install waywall on Fedora:
-  - First install the dependencies with the following terminal command:
+  - **Fedora 41 and below** 
+    - First install the dependencies with the following terminal command:
 
-    ```bash
-    sudo dnf install libspng-devel cmake meson mesa-libEGL-devel luajit-devel libwayland-client libwayland-server libwayland-cursor libxkbcommon-devel xorg-x11-server-Xwayland-devel wayland-protocols-devel wayland-scanner wayland-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel
-    ```
+      ```bash
+      sudo dnf install libspng-devel cmake meson mesa-libEGL-devel luajit-devel libwayland-client libwayland-server libwayland-cursor libxkbcommon-devel xorg-x11-server-Xwayland-devel wayland-protocols-devel wayland-scanner wayland-devel libXcursor-devel libXi-devel libXinerama-devel libXrandr-devel
+      ```
 
-  - Then, run the commands on [this page of the waywall documentation](https://tesselslate.github.io/waywall/00_installation.html#compiling) to compile waywall from source.
+    - Then, run the commands on [this page of the waywall documentation](https://tesselslate.github.io/waywall/00_installation.html#compiling) to compile waywall from source.
+    
 
-- On Arch Linux, [you can install waywall through the AUR](https://aur.archlinux.org/packages/waywall-working-git).
-- Users on Debian-based distros may have trouble building waywall manually due to certain dependencies being far out of date. If you're having trouble, join the [Linux MCSR Discord server](https://discord.gg/3tm4UpUQ8t).
+- On **Arch Linux**, [you can install waywall through the AUR](https://aur.archlinux.org/packages/waywall-working-git).
+- On **Debian** , prebuilt binaries are available for waywall however they only work with **Debian 13 and up** as older version do not have updated dependancies to run waywall. Please download `.deb` version from [releases of waywall](https://github.com/tesselslate/waywall/releases).  
+  - Installtion of package can be done by double clicking on `.deb` and installing using default system install.
+  - In any other case apt can be used to install .deb packages using following command.
+  `sudo apt install locationTodebfile` eg. `sudo apt install ~/Downloads/waywall.deb`
+- On **Ubuntu**/**Ubuntu based Distros (Linux Mint, MX Linux, Pop OS! etc)**, 
+  
+  - **Ubuntu 26.04** has been tested and verified  working with waywall using `.deb` package. Follow the same installations instruction as Debian.
+  - **Linux Mint 22.3 and below/Any distro based on Ubuntu 24.04 or below** cannot run waywall due outdated dependancies and should use switch to x11 and use [resetti](../x11/resetti.html) instead. 
 
+## Verification of installation and next steps
 - Run `waywall` in a terminal to check it's installed properly.
-  - Use the absolute path to the waywall executable if this doesn't work (i.e. if you built waywall in `/home/username/waywall/build/waywall`, run `/home/username/waywall/build/waywall/waywall`).
-  - The wrapper command for your instance in the next step should also use this path instead of `waywall`.
+it should produce similar ouput:
+  ```waywall
+
+  Usage:
+          waywall wrap -- CMD      Run the specified command in a new waywall instance
+
+  Options:
+          --profile PROFILE        Run waywall with the given configuration profile
+          --allow-mc-x11           Allows Minecraft to run under X11. This will result
+                                  in a degraded experience.
+          --no-env-reexec          Disable re-executing waywall with the parent process'
+                                  environment
+  ```
+- In case it doesn't or ouputs waywall command not found.
+  - If you have installed waywall from prebuilt binaries, verify that waywall exist in following path `/usr/bin/waywall` in case it doesn't please reinstall waywall.                           
+  - In case you are building waywall from source
+    - Use the absolute path to the waywall executable and verify it works (i.e. if you built waywall in `/home/username/waywall/build/waywall`, run `/home/username/waywall/build/waywall/waywall`).
+    - The wrapper command for your instance in the next step should also reflect this path in your launcher i.e instead of `waywall wrap --`, it should be path where waywall build is present i.e `/home/username/waywall/build/waywall/waywall wrap --`
 - Once waywall is installed properly, visit the [next page of the documentation](https://tesselslate.github.io/waywall/00_setup.html) to patch GLFW and set up your instance to launch within waywall.
 
 - After this, move to the [next section](waywall-config.html) to install an example config and learn how to customize it to your liking.

--- a/doc/minecraft/wayland/waywall.md
+++ b/doc/minecraft/wayland/waywall.md
@@ -10,11 +10,11 @@
 
 ## Installation
 - To install waywall on **Fedora**:
-  - **Fedora 42 onwards**, prebuilt binaries are available and is **recommended** way to install waywall. Please download `**.x86_64.rpm` package from [releases of waywall](https://github.com/tesselslate/waywall/releases). 
-    - If you are using KDE Plasma(default with Desktop edition of Fedora), installation can be done by double clicking on .rpm file and installing it via Discover app.
+  - **Fedora 42 onwards**, prebuilt binaries are available and is recommended way to install waywall. Please download the `.x86_64.rpm` package from [releases of waywall](https://github.com/tesselslate/waywall/releases). 
+    - If you are using KDE Plasma (default with Desktop edition of Fedora), installation can be done by double clicking on .rpm file and installing it via Discover app.
     - In any other case you can use, `sudo rpm -i [path_to_rpm_file]` provide path to `.rpm` file. 
-    
-      Expample: `sudo dnf install ~/Downloads/waywall.x86_64.rpm`
+
+      Example: `sudo dnf install ~/Downloads/waywall.x86_64.rpm`
     
 
   - **Fedora 41 and below** 
@@ -28,18 +28,18 @@
     
 
 - On **Arch Linux**, [you can install waywall through the AUR](https://aur.archlinux.org/packages/waywall-working-git).
-- On **Debian** , prebuilt binaries are available for waywall however they only work with **Debian 13 and up** as older versions do not have updated dependancies to run waywall. Please download `.deb` version from [releases of waywall](https://github.com/tesselslate/waywall/releases).  
-  - Installtion of package can be done by double clicking on `.deb` and installing using default system install.
+- On **Debian** , prebuilt binaries are available for waywall however they only work with **Debian 13 and up** as older versions do not have updated dependencies to run waywall and older versions should use x11 and [resetti](../x11/resetti.html) instead. Please download `.deb` version from [releases of waywall](https://github.com/tesselslate/waywall/releases).  
+  - Installation of package can be done by double clicking on `.deb` and installing using default system install.
   - In any other case apt can be used to install .deb packages using following command.
   `sudo apt install locationTodebfile` eg. `sudo apt install ~/Downloads/waywall.deb`
-- On **Ubuntu**/**Ubuntu based Distros (Linux Mint, MX Linux, Pop OS! etc)**, 
+- On **Ubuntu**/**Ubuntu based Distros (Linux Mint, MX Linux, Pop OS! etc)**,  
   
   - **Ubuntu 26.04** has been tested and verified  working with waywall using `.deb` package. Follow the same installations instruction as Debian.
-  - **Linux Mint 22.3 and below/Any distro based on Ubuntu 24.04 or below** cannot run waywall due outdated dependancies and should switch to x11 and use [resetti](../x11/resetti.html) instead. 
+  - **Linux Mint 22.3 and below/Any distro based on Ubuntu 24.04 or below** cannot run waywall due outdated dependencies and should switch to x11 and use [resetti](../x11/resetti.html) instead.
 
 ## Verification of installation and next steps
 - Run `waywall` in a terminal to check it's installed properly.
-it should produce similar ouput:
+  it should produce similar output:
   ```waywall
 
   Usage:
@@ -52,11 +52,11 @@ it should produce similar ouput:
           --no-env-reexec          Disable re-executing waywall with the parent process'
                                   environment
   ```
-- In case it doesn't or ouputs waywall command not found
+- In case it doesn't or outputs waywall command not found
   - If you have installed waywall from prebuilt binaries, verify that waywall exist in following path `/usr/bin/waywall` in case it doesn't please reinstall waywall.                           
   - In case you are building waywall from source
     - Use the absolute path to the waywall executable and verify it works (i.e. if you built waywall in `/home/username/waywall/build/waywall`, run `/home/username/waywall/build/waywall/waywall`).
-    - The wrapper command for your instance in the next step should also reflect this path in your launcher .i.e instead of `waywall wrap --`, it should be path where waywall build is present i.e `/home/username/waywall/build/waywall/waywall wrap --`
+    - The wrapper command for your instance in the next step should also reflect this path in your launcher. i.e., instead of `waywall wrap --`, it should be the path to your built waywall executable, e.g. `/home/username/waywall/build/waywall/waywall wrap --`
 - Once waywall is installed properly, visit the [next page of the documentation](https://tesselslate.github.io/waywall/00_setup.html) to patch GLFW and set up your instance to launch within waywall.
 
 - After this, move on to the [next section](waywall-config.html) to install an example config and learn how to customize it to your liking.

--- a/doc/post_install/java.md
+++ b/doc/post_install/java.md
@@ -1,18 +1,44 @@
 # Java
 
-- Open up a terminal and type in these commands:
+- **Installation**
+  - **Fedora 44 and onwards** OpenJDK builds are removed in favor of Adoptium Temurin OpenJDKs, please follow following instructions to install Temurin OpenJDKs. Run these commands one after another.
+    
+    1.  ```bash 
+        sudo dnf install adoptium-temurin-java-repository
+        ```
+    2.  ```bash
+        sudo fedora-third-party enable
+        ```
+    3.  Install appropriate version using  `sudo dnf install temurin-<version>-jdk` replace `<version>` with the required version.
+    Example:
+        ```bash
+        sudo dnf install temurin-21-jdk
+        ```
+    4. Once Temurin JDK is installed change default Java version of your system using following command and select Temurin JDK by typing appropriate number from JDK list and enter.
+        ```
+        sudo alternatives --config java
+        ```
+    5. Once you have set correct JDK, you can verify by running in the terminal `java --version` should get similar ouput where it shows current JDK being used, it should be the Temurin one.
+        ```bash
+        openjdk 21.0.12 2026-07-21 LTS
+        OpenJDK Runtime Environment Temurin-21.0.12+8 (build 21.0.12+8-LTS)
+        OpenJDK 64-Bit Server VM Temurin-21.0.12+8 (build 21.0.12+8-LTS, mixed mode, sharing)
+        ```
+  - **Fedora 43 and below versions**
+    - Open up a terminal and type in these commands:
+      ```bash
+      sudo dnf install java-21-openjdk
+      ```
+    - This will install and setup the Java JDK for you.
+    - Remember! JDK versions will be named in the same format. So JDK 11 would be named as **java-11-openjdk** and so on. So if you want to install other versions of the JDK you follow the same format. Its easy, isn't it? :D
 
-```bash
-sudo dnf install java-21-openjdk
-```
+- **Running Jar files**
 
-- This will install and setup the Java JDK for you.
-- Remember! JDK versions will be named in the same format. So JDK 11 would be named as **java-11-openjdk** and so on. So if you want to install other versions of the JDK you follow the same format. Its easy, isn't it? :D
-- To run .jar files, such as ModCheck or Ninjabrain Bot, you can use the following terminal command, replacing `<path/to/jarfile.jar>` with the actual path to the .jar file:
+  To run .jar files, such as ModCheck or Ninjabrain Bot, you can use the following terminal command, replacing `<path/to/jarfile.jar>` with the actual path to the .jar file:
 
-```bash
-java -jar <path/to/jarfile.jar>
-```
+  ```bash
+  java -jar <path/to/jarfile.jar>
+  ```
 
 ## GraalVM
 


### PR DESCRIPTION
Fixed waywall installation instructions for fedora and debian and more specific stuff related to ubuntu.
Added more verbosity for ubuntu and debian based system , move waywall running and verification to seperate section.